### PR TITLE
update for 6to5 -> Babel rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
-# ember-cli-6to5
+# ember-cli-babel
 
-This Ember-CLI plugin uses [6to5](https://6to5.org/index.html) to allow you to use ES6 syntax with your
+This Ember-CLI plugin uses [Babel](https://babeljs.io/) to allow you to use ES6 syntax with your
 Ember-CLI project.
 
 ## Installation
 
 ```
-npm install --save-dev ember-cli-6to5
+npm install --save-dev ember-cli-babel
 ```
 
 ## Usage
 
 This plugin should work without any configuration after installing. By default it will take every `.js` file
-in your project and run it through the 6to5 transpiler to convert the ES6 code to ES5. Running existing ES5 code
+in your project and run it through the Babel transpiler to convert the ES6 code to ES5. Running existing ES5 code
 through the transpiler shouldn't change the code at all (likely just a format change if it does).
 
-If you need to customize the way that 6to5 transfoms your code, you can do it by passing in any of the options
-found [here](https://6to5.org/docs/usage/options/). Example:
+If you need to customize the way that Babel transfoms your code, you can do it by passing in any of the options
+found [here](https://babeljs.io/docs/usage/options/). Example:
 
 ```js
 // Brocfile.js
 
 var app = new EmberApp({
-	'6to5': {
+	'babel': {
 		// disable comments
 		comments: false
 	}
@@ -32,7 +32,7 @@ var app = new EmberApp({
 ### About Modules
 
 Ember-CLI uses its own ES6 module transpiler for the custom Ember resolver that it uses. Because of that,
-this plugin disables 6to5 module compilation by blacklisting that transform. If you find that you want to use
-the 6to5 module transform instead of the Ember-CLI one, you'll have to explicitly set `compileModules` to `true`
+this plugin disables Babel module compilation by blacklisting that transform. If you find that you want to use
+the Babel module transform instead of the Ember-CLI one, you'll have to explicitly set `compileModules` to `true`
 in your configuration. If `compileModules` is anything other than `true`, this plugin will leave the module
 syntax compilation up to Ember-CLI.

--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
 module.exports = {
-  name: 'ember-cli-6to5',
+  name: 'ember-cli-babel',
   included: function(app) {
     this._super.included.apply(this, arguments);
 
-    var options = getOptions(app.options['6to5']);
+    var options = getOptions(app.options['babel']);
 
     var plugin = {
-      name: 'ember-cli-6to5',
+      name: 'ember-cli-babel',
       ext: 'js',
       toTree: function(tree) {
-        return require('broccoli-6to5-transpiler')(tree, options);
+        return require('broccoli-babel-transpiler')(tree, options);
       }
     };
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-cli-6to5",
+  "name": "ember-cli-babel",
   "version": "3.0.0",
   "main": "index.js",
   "keywords": [
@@ -9,14 +9,14 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/6to5/ember-cli-6to5.git"
+    "url": "git://github.com/babel/ember-cli-babel.git"
   },
   "bugs": {
-    "url": "https://github.com/6to5/ember-cli-6to5/issues"
+    "url": "https://github.com/babel/ember-cli-babel/issues"
   },
-  "homepage": "https://github.com/6to5/ember-cli-6to5",
+  "homepage": "https://github.com/babel/ember-cli-babel",
   "dependencies": {
-    "broccoli-6to5-transpiler": "^3.0.0",
+    "broccoli-babel-transpiler": "^4.0.0",
     "broccoli-filter": "^0.1.10"
   }
 }


### PR DESCRIPTION
The 6to5 project has been renamed to Babel. This updates docs,
code, and dependencies (via package.json) to reflect that.